### PR TITLE
change path of tutorial.Rmd

### DIFF
--- a/vignettes/tutorial.Rmd
+++ b/vignettes/tutorial.Rmd
@@ -26,7 +26,7 @@ documentation of the manuscript.  See [manuscripts/README] for more
 details about this functionality.  
 
 
-**Note**: This README is created programmatically from [manuscripts/tutorial.Rmd],
+**Note**: This README is created programmatically from [vignettes/tutorial.Rmd],
 so edit that file and not the README itself.  (This lets the README include 
 executed R code and keeps it in sync with an R package vignette).  
 


### PR DESCRIPTION
I came here from your reply to my comment on your blog about packrat, thanks for the update, this looks very interesting, a manuscript as R package, a great idea. There's nothing at manuscripts/tutorial.Rmd, so I'm guessing it's vignettes/tutorial.Rmd? In any case thought I'd let you know the link is broken.

I just noticed a second location for the readme, mentioned here: https://github.com/cboettig/template/blob/master/CONTRIBUTING.md

"Likewise, the README.md file in the base directory should not be edited directly. This file is created automatically from code that runs the examples shown, helping to ensure that they are functioning as advertised and consistent with the package README vignette. Instead, edit the README.Rmd source file in inst/doc/pubs and run make to build the README."

I can't see an inst/doc/pubs in this repo, maybe those contributing instructions need an update also, or am I missing something?
